### PR TITLE
Use port 8080

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ COPY . /app
 WORKDIR /app
 
 ENTRYPOINT ["flask"]
-CMD ["run", "--host=0.0.0.0"]
+CMD ["run", "--host=0.0.0.0", "-p", "8080"]


### PR DESCRIPTION
Use port 8080 in docker image. To expose service correctly in Zarvis.

https://community-zarvis--ai.g1.zarvis.ai/getting_started/dockerfile.html