### PR TITLE
Hungarian service provider list cleanup

### DIFF
--- a/email-providers.csv
+++ b/email-providers.csv
@@ -8108,6 +8108,7 @@ vip-mail.tk
 vip.gr
 vip.qq.com
 vip.sina.com
+vipmail.hu
 vipmail.name
 vipmail.pw
 vipmail.ru

--- a/email-providers.csv
+++ b/email-providers.csv
@@ -1267,6 +1267,7 @@ cinci.rr.com
 cincinow.net
 citeweb.net
 citlink.net
+citromail.hu
 city-of-bath.org
 city-of-birmingham.com
 city-of-brighton.org
@@ -2137,6 +2138,7 @@ etranquil.org
 eu.igg.biz
 euaqa.com
 eudoramail.com
+euromail.hu
 europe.com
 europemail.com
 euroseek.com
@@ -3248,6 +3250,7 @@ incognitomail.org
 incq.com
 incredimail.com
 ind.st
+indamail.hu
 indexa.fr
 india.com
 indiatimes.com

--- a/email-providers.csv
+++ b/email-providers.csv
@@ -430,7 +430,6 @@ aistis.xyz
 ajacied.com
 ajaxapp.net
 aji.kr
-ak47.hu
 akademiyauspexa.xyz
 akapost.com
 akash9.gq
@@ -511,7 +510,6 @@ altuswe.us
 alumni.com
 alumnidirector.com
 alumnimp3.xyz
-alvilag.hu
 ama-trade.de
 ama-trans.de
 amadamus.com
@@ -877,7 +875,6 @@ bfo.kr
 bgtmail.com
 bgx.ro
 bharatmail.com
-bho.hu
 bho.kr
 bickmail.com.au
 bidourlnks.com
@@ -1823,7 +1820,6 @@ droplar.com
 droplister.com
 dropmail.me
 dropzone.com
-drotposta.hu
 drynic.com
 dsiay.com
 dslextreme.com
@@ -2096,7 +2092,6 @@ ephemail.net
 ephemeral.email
 epix.net
 epost.de
-eposta.hu
 eqeqeqeqe.tk
 eqiluxspam.ga
 eqqu.com
@@ -2641,7 +2636,6 @@ geartower.com
 gee-wiz.com
 geecities.com
 geek.com
-geek.hu
 geeklife.com
 geew.ru
 gehensiemirnichtaufdensack.de
@@ -2880,8 +2874,6 @@ gynzy.mobi
 gynzy.pl
 gynzy.ro
 gynzy.sk
-gyorsposta.com
-gyorsposta.hu
 gzb.ro
 h.mintemail.com
 h1z8ckvz.com
@@ -2950,7 +2942,6 @@ hecat.es
 heerschap.com
 heesun.net
 hehe.com
-hello.hu
 hello.net.au
 hello.to
 hellodream.mobi
@@ -3443,7 +3434,6 @@ jmail.ro
 jnxjn.com
 jo-mail.com
 job4u.com
-jobbikszimpatizans.hu
 jobposts.net
 jobs-to-be-done.net
 joelpet.com
@@ -3545,7 +3535,6 @@ keromail.com
 ketiksms.club
 key-mail.net
 keyemail.com
-kgb.hu
 khosropour.com
 khtyler.com
 kiani.com
@@ -3701,7 +3690,6 @@ letsmail9.com
 letterbox.com
 letthemeatspam.com
 levele.com
-levele.hu
 lex.bg
 lexis-nexis-mail.com
 lexisense.com
@@ -3879,7 +3867,6 @@ macromaid.com
 madcreations.com
 madonnafan.com
 madrid.com
-maffia.hu
 magamail.com
 maggotymeat.ga
 magicbox.ro
@@ -3959,7 +3946,6 @@ mail.sisna.com
 mail.spaceports.com
 mail.theboys.com
 mail.usa.com
-mail.vasarhely.hu
 mail.vrfarm.com.tw
 mail.wtf
 mail.zp.ua
@@ -5529,7 +5515,6 @@ mchsi.com
 mciek.com
 mciworldcom.net
 md5hashing.net
-me-mail.hu
 me.com
 mechanicalresumes.com
 medical.net.au
@@ -6312,7 +6297,6 @@ pcpostal.com
 pcsrock.com
 pcusers.otherinbox.com
 pdold.com
-pe.hu
 peachworld.com
 peapz.com
 pecdo.com
@@ -6396,7 +6380,6 @@ plw.me
 pmail.net
 po.bot.nu
 pobox.com
-pobox.hu
 pobox.sk
 pochta.ru
 poczta.fm
@@ -7150,7 +7133,6 @@ soioa.com
 soisz.com
 sol.dk
 solar-impact.pro
-soldier.hu
 solution4u.com
 solvemail.info
 solventtrap.wiki


### PR DESCRIPTION
**Added providers:**
- citromail.hu
- euromail.hu
- indamail.hu
- vipmail.hu

**Removed providers:**
- ak47.hu
- alvilag.hu
- bho.hu
- drotposta.hu
- eposta.hu
- geek.hu
- gyorsposta.com
- gyorsposta.hu
- hello.hu
- jobbikszimpatizans.hu
- kgb.hu
- levele.hu
- maffia.hu
- mail.vasarhely.hu
- me-mail.hu
