### PR TITLE
remove some invalid domains, add more CI checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,9 @@ jobs:
     - name: Install dependencies
       run: |
         pip install tldextract
+    - name: Domains are unique and sorted check
+      run: |
+        python checks/unique-and-sorted-check.py
     - name: Valid domain check
       run: |
         python checks/valid-domain-check.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: email providers
 on: [push, pull_request]
 
 jobs:
-  license-check:
+  web-app-check:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v1
@@ -13,3 +13,13 @@ jobs:
     - name: Run test
       run: |
         python app_test.py
+  provider-list-check:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install dependencies
+      run: |
+        pip install tldextract
+    - name: Valid domain check
+      run: |
+        python checks/valid-domain-check.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pyc
+.tld_cache

--- a/checks/unique-and-sorted-check.py
+++ b/checks/unique-and-sorted-check.py
@@ -1,0 +1,27 @@
+def main():
+    provider_file = open('email-providers.csv', 'r')
+
+    provider_domains = []
+    all_good = True
+    for line in provider_file.readlines():
+        provider_domain = line.rstrip()
+        if provider_domain in provider_domains:
+            print('Duplicate entry: {}'.format(provider_domain))
+            all_good = False
+        if provider_domains:
+            previous_domain = provider_domains[-1]
+            current_order = [previous_domain, provider_domain]
+            if sorted(current_order) != current_order:
+                print('Wrong sorting: {} after {}'.format(
+                    provider_domain,
+                    previous_domain,
+                ))
+                all_good = False
+        provider_domains.append(provider_domain)
+
+    if not all_good:
+        exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/checks/valid-domain-check.py
+++ b/checks/valid-domain-check.py
@@ -1,0 +1,26 @@
+from tldextract import TLDExtract
+
+# cache locally, where we can write files
+no_fetch_extract = TLDExtract(cache_file='./.tld_cache')
+
+
+def main():
+    provider_file = open('email-providers.csv', 'r')
+
+    all_good = True
+    for line in provider_file.readlines():
+        provider_domain = line.rstrip()
+        domain_parts = no_fetch_extract(provider_domain)
+        if not (domain_parts.domain and domain_parts.suffix):
+            all_good = False
+            print('Not a valid domain: {} ({})'.format(
+                provider_domain,
+                domain_parts,
+            ))
+
+    if not all_good:
+        exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/email-providers.csv
+++ b/email-providers.csv
@@ -1386,7 +1386,6 @@ colorweb.cf
 columbus.rr.com
 columbusrr.com
 columnist.com
-com.ar
 comcast.net
 comic.com
 comilzilla.org
@@ -5885,7 +5884,6 @@ net-pager.net
 net-shopping.com
 net-solution.info
 net.email.ne.jp
-net.ua
 net4b.pt
 net4you.at
 netbounce.com
@@ -6005,7 +6003,6 @@ nogmailspam.info
 noicd.com
 noifeelings.com
 nokiamail.com
-nom.za
 nomail.cf
 nomail.ch
 nomail.ga
@@ -6182,7 +6179,6 @@ orangotango.tk
 orbitel.bg
 ordinaryamerican.net
 oreidresume.com
-org.ua
 orgmail.net
 orgmbx.cc
 oroki.de
@@ -8247,7 +8243,6 @@ web-mail.de
 web-mail.pp.ua
 web-police.com
 web.de
-web.id
 web2mailco.com
 webarnak.fr.eu.org
 webave.com
@@ -8725,7 +8720,6 @@ zonnet.nl
 zoominternet.net
 zoqqa.com
 zoutlook.com
-zp.ua
 zsero.com
 zubee.com
 zumpul.com

--- a/email-providers.csv
+++ b/email-providers.csv
@@ -2,7 +2,6 @@
 001.igg.biz
 027168.com
 0815.ru
-0815.ry
 0815.su
 0845.ru
 0ak.org
@@ -1168,7 +1167,6 @@ cavi.mx
 cazis.fr
 cbair.com
 cbes.net
-cc.liamria
 ccnmail.com
 cd.mintemail.com
 cd2.com
@@ -3061,7 +3059,6 @@ hotmail.com.ar
 hotmail.com.au
 hotmail.com.br
 hotmail.com.mx
-hotmail.con
 hotmail.de
 hotmail.dk
 hotmail.es
@@ -3082,7 +3079,6 @@ hotpop3.com
 hotvoice.com
 housat.com
 housefan.com
-housefancom
 housemail.com
 hpc.tw
 hroundb.com
@@ -6019,7 +6015,6 @@ nomail.xl.cx
 nomail2me.com
 nomailthankyou.com
 nomorespamemails.com
-nonexisted.nondomain
 nonpartisan.com
 nonspam.eu
 nonspammer.de
@@ -7106,7 +7101,6 @@ smsforum.ro
 smtp99.com
 smwg.info
 snail-mail.net
-snail-mail.ney
 snakebite.com
 snakemail.com
 sndt.net
@@ -8269,7 +8263,6 @@ webjump.com
 webm4il.in
 webm4il.info
 webmail.bellsouth.net
-webmail.co.yu
 webmail.co.za
 webmail.hu
 webmail24.to
@@ -8519,7 +8512,6 @@ yahoo.com.cn
 yahoo.com.es
 yahoo.com.hk
 yahoo.com.is
-yahoo.com.malaysia
 yahoo.com.mx
 yahoo.com.my
 yahoo.com.ph


### PR DESCRIPTION
I noticed that some domains are invalid and some are just top level domains (usually with two parts e.g. `com.ar`, so if you would try to extract the domain of an email address by taking the part before and after the last `.` you would get that).

I also wrote some simple CI checks to make sure that the list stays unique and sorted and that the domain is valid (a domain part and a TLD part) according to the popular python package [`tldextract`](https://pypi.org/project/tldextract/), building up on the great work @edwin-zvs already did with GitHub actions.

I added the two list checks as separate checks, so that we keep the list checking separate from the Flask API tests. I'm thinking about adding another check that resolves the domains and checks e.g. for MX records, but would like to get feedback on that first (that's another issue probably).

If we go ahead with this we can add a `CONTRIBUTING.md` file to help potential contributors run these checks locally before they commit and to make them aware of the CI checks on their PRs.

Usually I would create a issue before making a PR like this, but I got the in flow while writing these scripts initially to just update the `email-providers.csv` file. I'm happy to make changes based on your feedback.